### PR TITLE
Backward navigation fix in RTL mode

### DIFF
--- a/src/js/owl.navigation.js
+++ b/src/js/owl.navigation.js
@@ -331,6 +331,10 @@
 		var position, length,
 			settings = this._core.settings;
 
+		if (settings.rtl) {
+			successor = !successor;
+		}
+
 		if (settings.slideBy == 'page') {
 			position = $.inArray(this.current(), this._pages);
 			length = this._pages.length;


### PR DESCRIPTION
Fix for getPosition ignoring right to left layout that results in backward navigation by nav buttons for right to left layout mode