### PR TITLE
Revert "Backward navigation fix in RTL mode"

### DIFF
--- a/src/js/owl.navigation.js
+++ b/src/js/owl.navigation.js
@@ -331,10 +331,6 @@
 		var position, length,
 			settings = this._core.settings;
 
-		if (settings.rtl) {
-			successor = !successor;
-		}
-
 		if (settings.slideBy == 'page') {
 			position = $.inArray(this.current(), this._pages);
 			length = this._pages.length;


### PR DESCRIPTION
~~Fix for getPosition ignoring right to left layout that results in backward navigation by nav buttons for right to left layout mode~~
Seems like the order of owl-items were reverted due to a conflict with another library. Closing.